### PR TITLE
Add keys to playertimes table

### DIFF
--- a/sql/patch-schema-2.sql
+++ b/sql/patch-schema-2.sql
@@ -88,7 +88,10 @@ CREATE TABLE playertimes (
   gameid VARCHAR(32) NOT NULL,
   userid VARCHAR(32) NOT NULL,
   time_in_minutes INT(5) unsigned not null,
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+  KEY `gameid` (`gameid`),
+  KEY `userid` (`userid`),
+  UNIQUE KEY `user_game` (`userid`, `gameid`)
 );
 
 -- Sample time values for The Tempest (by Grigg)


### PR DESCRIPTION
These keys ensure that we can quickly find all of the `playertimes` for a given game, or a given user, and it ensures that we never insert two `playertimes` for the same combination of games and users.