### PR TITLE
Search results call it `devsys` instead of `system`

### DIFF
--- a/www/components/games.php
+++ b/www/components/games.php
@@ -69,7 +69,7 @@ for ($idx = 0 ; $idx <= 5; $idx++)
             . "</i></b></a>, by "
             . htmlspecialcharx($g['author']);
 
-        if ($g['system']) echo " <div class=details>{$g['system']}</div>";
+        if ($g['devsys']) echo " <div class=details>{$g['devsys']}</div>";
 
         echo "</div>";
     }


### PR DESCRIPTION
> I’m not sure why, but on the home page, in the games section, the live site shows authoring systems, but the dev site does not. This happens regardless of whether I set a filter.

This is because we're using `searchutil` to get the game data, but search results call it `devsys` instead of `system`. This PR updates the home page to look for `devsys`, bringing the system back on the home page.

https://github.com/iftechfoundation/ifdb/blob/c5bfed02e0f5016dc6a3a42d03b9d355184ce1a5/www/searchutil.php#L263

