### PR TITLE
Always search games for new reviews

### DIFF
--- a/www/newitems.php
+++ b/www/newitems.php
@@ -176,6 +176,8 @@ function getNewItems($db, $limit, $itemTypes = NEWITEMS_ALLITEMS, $options = [],
         $sortby = "recently_reviewed";
         $games_limit_clause = "limit $reviews_limit";
         $browse = 0;
+        // If the user has a custom game filter and has not overridden it, that 
+        // filter will automatically be applied within the doSearch function.
         list($game_rows_after_filtering, $rowcnt, $sortList, $errMsg, $summaryDesc, 
             $badges, $specials, $specialsUsed, $orderBy, $game_filter_was_applied) 
             = doSearch($db, $term, $searchType, $sortby, $games_limit_clause, $browse);

--- a/www/newitems.php
+++ b/www/newitems.php
@@ -176,7 +176,9 @@ function getNewItems($db, $limit, $itemTypes = NEWITEMS_ALLITEMS, $options = [],
         $sortby = "recently_reviewed";
         $games_limit_clause = "limit $reviews_limit";
         $browse = 0;
-        [$game_rows_after_filtering] = doSearch($db, $term, $searchType, $sortby, $games_limit_clause, $browse);
+        list($game_rows_after_filtering, $rowcnt, $sortList, $errMsg, $summaryDesc, 
+            $badges, $specials, $specialsUsed, $orderBy, $game_filter_was_applied) 
+            = doSearch($db, $term, $searchType, $sortby, $games_limit_clause, $browse);
         // Note the gameids of games that we might want to display reviews for
         foreach ($game_rows_after_filtering as $game_row) {
             $gameids_after_filtering[] = "'" . $game_row['id'] . "'";

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -285,15 +285,8 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
         $baseWhere = "";
         $groupBy = "";
         $baseOrderBy = "";
-        if ($browse && ($sortby == "" || $sortby == "ratu" || $sortby == "ratd" || $sortby == "rcu")) {
-            // when sorting by highest/lowest/most ratings, we can optimize by
-            // fetching the top N from the gameRatingsView
-            $tableList = "games
-                          join ".getGameRatingsView($db)." on games.id = gameid";
-        } else {
-            $tableList = "games
-                          left join ".getGameRatingsView($db)." on games.id = gameid";
-        }
+        $tableList = "games
+                      join ".getGameRatingsView($db)." on games.id = gameid";
         $matchCols = "title, author, `desc`, tags";
         $likeCol = "title";
         $summaryDesc = "Games";


### PR DESCRIPTION
Fixes #1275

I'm feeling kinda confused, and, before we merge this, you might want to double-check my work.

First off, I'm quite surprised to see that #1275 is happening in the `main` branch. I could've _sworn_ I checked for this, but I can't see how this query could ever have possibly avoided a full scan. It's checking for `reviews` rows that have a non-null written review, but there's no key for that.

So I figured the best way to fix it would be to just have _everybody_ use the new code that first searches for games with new reviews.

To actually make the reviews query benefit from this, I had to convert the `$games_after_filtering` post-query filtering code into SQL, adding a `gameid in (...)`.

But then, I went in and explained the game-search query, just to be safe.

```
MariaDB [ifdb]> explain select
    ->               distinct games.id as id,
    ->                        games.title as title,
    ->                        games.author as author,
    ->                        games.desc as description,
    ->                        games.tags as tags,
    ->                        games.created as createdate,
    ->                        games.moddate as moddate,
    ->                        games.system as devsys,
    ->                        if (time(games.published) = '00:00:00',
    ->                            date_format(games.published, '%Y'),
    ->                            date_format(games.published, '%M %e, %Y'))
    ->                          as pubfmt,
    ->                        if (time(games.published) = '00:00:00',
    ->                            date_format(games.published, '%Y'),
    ->                            date_format(games.published, '%Y-%m-%d'))
    ->                          as published,
    ->                        date_format(games.published, '%Y') as pubyear,
    ->                        (games.coverart is not null) as hasart,
    ->                        avgRating as avgrating,
    ->                        numRatingsInAvg as ratingcnt,
    ->                        stdDevRating as ratingdev,
    ->                        numRatingsTotal,
    ->                        numMemberReviews,
    ->                        lastReviewDate,
    ->                        starsort,
    ->                        games.sort_title as sort_title,
    ->                        games.sort_author as sort_author,
    ->                        ifnull(games.published, '9999-12-31') as sort_pub,
    ->                        games.pagevsn,
    ->                        games.flags
    ->
    ->             from
    ->               games
    ->                           left join gameRatingsSandbox0_mv on games.id = gameid
    ->
    ->             where
    ->               lastReviewDate >= date_sub(now(), interval 365 day)
    ->
    ->
    ->
    ->             order by
    ->               lastReviewDate desc
    ->
    ->             limit 8;
```
```
+------+-------------+------------------------+--------+------------------------+----------------+---------+------------------------------------+------+------------------------------+
| id   | select_type | table                  | type   | possible_keys          | key            | key_len | ref                                | rows | Extra                        |
+------+-------------+------------------------+--------+------------------------+----------------+---------+------------------------------------+------+------------------------------+
|    1 | SIMPLE      | gameRatingsSandbox0_mv | range  | PRIMARY,lastReviewDate | lastReviewDate | 5       | NULL                               | 1217 | Using where; Using temporary |
|    1 | SIMPLE      | games                  | eq_ref | PRIMARY                | PRIMARY        | 130     | ifdb.gameRatingsSandbox0_mv.gameid | 1    |                              |
+------+-------------+------------------------+--------+------------------------+----------------+---------+------------------------------------+------+------------------------------+
```

That seems like way more rows than needed, (we need no more than 8 games) so I poked around with the query some more. It turns out that we don't need the `lastreview:` query filter at all!

That query term was my idea in my [long post about performance](https://intfiction.org/t/allow-users-to-add-a-custom-filter-to-all-game-searches/72443/80?u=dfabulich)… and it looks like the reason it was needed was the `left join` to `gameRatingsSandbox0_mv`. I merged #1273 into this branch, and then, the `lastreview:` filter isn't needed.

I dunno. It seems to do the right thing for logged out users, and it worked when I set `language:de` as my custom search filter, even without a date limit.