### PR TITLE
Add `lastReviewDate` to `gameRatingsSandbox01`

### DIFF
--- a/sql/unscrub-ifarchive.sql
+++ b/sql/unscrub-ifarchive.sql
@@ -488,6 +488,7 @@ select `averaged`.`gameid` AS `gameid`,
   `averaged`.`numRatingsInAvg` AS `numRatingsInAvg`,
   `averaged`.`numRatingsTotal` AS `numRatingsTotal`,
   `averaged`.`numMemberReviews` AS `numMemberReviews`,
+  `averaged`.`lastReviewDate` AS `lastReviewDate`,
   `averaged`.`avgRating` AS `avgRating`,
   pow(
     (
@@ -535,6 +536,7 @@ from (
       `rating_counts`.`numRatingsInAvg` AS `numRatingsInAvg`,
       `rating_counts`.`numRatingsTotal` AS `numRatingsTotal`,
       `rating_counts`.`numMemberReviews` AS `numMemberReviews`,
+      `rating_counts`.`lastReviewDate` AS `lastReviewDate`,
 (
         `rating_counts`.`rated1`
         + `rating_counts`.`rated2` * 2
@@ -597,13 +599,20 @@ from (
               when `grouped`.`hasReview` then `grouped`.`count`
               else 0
             end
-          ) AS `numMemberReviews`
+          ) AS `numMemberReviews`,
+          max(
+            case
+              when `grouped`.`hasReview` then `grouped`.`lastRatingOrReviewDate`
+              else null
+            end
+          ) AS `lastReviewDate`
         from (
             select count(`ifdb`.`reviews`.`id`) AS `count`,
               `ifdb`.`reviews`.`rating` AS `rating`,
               `ifdb`.`games`.`id` AS `gameid`,
               ifnull(`ifdb`.`reviews`.`RFlags`, 0) & 2 AS `omitted`,
-              `ifdb`.`reviews`.`review` is not null AS `hasReview`
+              `ifdb`.`reviews`.`review` is not null AS `hasReview`,
+              max(ifnull(embargodate, createdate)) AS `lastRatingOrReviewDate`
             from (
                 `ifdb`.`games`
                 left outer join `ifdb`.`reviews` on (


### PR DESCRIPTION
I found a bug in #1199.

* Login as ifdbadmin
* Go to Admin --> User list --> Test Tester http://localhost:8080/adminops?user=0000000000000001
* Set Test Tester to Sandbox, Apply, and Log in as Test Tester
* Go to the home page

The reviews section is busted, and there's an error on the Docker log:

> Unknown column 'lastReviewDate' in 'SELECT'

This is happening because sandboxed users don't use `gameRatingsSandbox0_mv` or its underlying view `gameRatingsSandbox0`. They use the `gameRatingsSandbox01` view, which incorporates reviews and other content from sandboxed users.

In this PR, I've copied and pasted the changes to `gameRatingsSandbox0` into `gameRatingsSandbox01`. This fixes the bug.