### PR TITLE
Fix `refresh_gameRatingsSandbox0_mv` stored procedure

### DIFF
--- a/sql/patch-full-schema.sql
+++ b/sql/patch-full-schema.sql
@@ -404,10 +404,10 @@ where gameid = new_gameid into @gameid,
     @numRatingsInAvg,
     @numRatingsTotal,
     @numMemberReviews,
+    @lastReviewDate,
     @avgRating,
     @stdDevRating,
-    @starsort,
-    @lastReviewDate;
+    @starsort;
 if @gameid is null then
     delete from gameRatingsSandbox0_mv where gameid = new_gameid;
 else
@@ -422,10 +422,10 @@ values (
         @numRatingsInAvg,
         @numRatingsTotal,
         @numMemberReviews,
+        @lastReviewDate,
         @avgRating,
         @stdDevRating,
         @starsort,
-        @lastReviewDate,
         now()
     ) on duplicate key
 update gameid = @gameid,
@@ -437,10 +437,10 @@ update gameid = @gameid,
     numRatingsInAvg = @numRatingsInAvg,
     numRatingsTotal = @numRatingsTotal,
     numMemberReviews = @numMemberReviews,
+    lastReviewDate = @lastReviewDate,
     avgRating = @avgRating,
     stdDevRating = @stdDevRating,
     starsort = @starsort,
-    lastReviewDate = @lastReviewDate,
     updated = now();
 END IF;
 END;

--- a/sql/unscrub-ifarchive.sql
+++ b/sql/unscrub-ifarchive.sql
@@ -930,10 +930,10 @@ where gameid = new_gameid into @gameid,
     @numRatingsInAvg,
     @numRatingsTotal,
     @numMemberReviews,
+    @lastReviewDate,
     @avgRating,
     @stdDevRating,
-    @starsort,
-    @lastReviewDate;
+    @starsort;
 if @gameid is null then
     delete from gameRatingsSandbox0_mv where gameid = new_gameid;
 else
@@ -948,10 +948,10 @@ values (
         @numRatingsInAvg,
         @numRatingsTotal,
         @numMemberReviews,
+        @lastReviewDate,
         @avgRating,
         @stdDevRating,
         @starsort,
-        @lastReviewDate,
         now()
     ) on duplicate key
 update gameid = @gameid,
@@ -963,10 +963,10 @@ update gameid = @gameid,
     numRatingsInAvg = @numRatingsInAvg,
     numRatingsTotal = @numRatingsTotal,
     numMemberReviews = @numMemberReviews,
+    lastReviewDate = @lastReviewDate,
     avgRating = @avgRating,
     stdDevRating = @stdDevRating,
     starsort = @starsort,
-    lastReviewDate = @lastReviewDate,
     updated = now();
 END IF;
 END;


### PR DESCRIPTION
I got the column orders mixed up, so when creating/updating/deleting new reviews, `gameRatingsSandbox0_mv` wasn't getting updated properly.